### PR TITLE
Dcp more error check

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # todo re-asses if all of these must be *installed*
 LIST(APPEND libmfu_install_headers
   mfu.h
+  mfu_errors.h
   mfu_bz2.h
   mfu_flist.h
   mfu_flist_internal.h

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -1,0 +1,27 @@
+/* Defines common error codes */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef MFU_ERRORS_H
+#define MFU_ERRORS_H
+
+/* Generic error codes */
+#define ERR_INVAL_ARG EINVAL // 22
+
+/* DAOS specific error codes*/
+#define ERR_DAOS            40
+#define ERR_DAOS_INVAL_POOL 41
+#define ERR_DAOS_INVAL_CONT 42
+#define ERR_DAOS_INVAL_SVCL 43
+#define ERR_DAOS_INVAL_PRFX 44
+#define ERR_DAOS_ARG_REQ    45
+
+#endif /* MFU_ERRORS_H */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -13,11 +13,7 @@ extern "C" {
 
 /* DAOS specific error codes*/
 #define ERR_DAOS            40
-#define ERR_DAOS_INVAL_POOL 41
-#define ERR_DAOS_INVAL_CONT 42
-#define ERR_DAOS_INVAL_SVCL 43
-#define ERR_DAOS_INVAL_PRFX 44
-#define ERR_DAOS_ARG_REQ    45
+#define ERR_DAOS_INVAL_PRFX 41
 
 #endif /* MFU_ERRORS_H */
 

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -8,12 +8,21 @@ extern "C" {
 #ifndef MFU_ERRORS_H
 #define MFU_ERRORS_H
 
-/* Generic error codes */
-#define ERR_INVAL_ARG EINVAL // 22
+/* Convention:
+ * 0-99    -> Generic error codes
+ * 100-199 -> Utility-specific error codes
+ * 200-255 -> Other error codes */
 
-/* DAOS specific error codes*/
-#define ERR_DAOS            40
-#define ERR_DAOS_INVAL_PRFX 41
+/* Generic error codes */
+#define ERR_INVAL_ARG 10
+
+/* DCP-specific error codes */
+#define ERR_DCP      100
+#define ERR_DCP_COPY 101
+
+/* DAOS-specific error codes*/
+#define ERR_DAOS            200
+#define ERR_DAOS_INVAL_PRFX 201
 
 #endif /* MFU_ERRORS_H */
 

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -8,21 +8,21 @@ extern "C" {
 #ifndef MFU_ERRORS_H
 #define MFU_ERRORS_H
 
-/* Convention:
- * 0-99    -> Generic error codes
- * 100-199 -> Utility-specific error codes
- * 200-255 -> Other error codes */
-
 /* Generic error codes */
-#define ERR_INVAL_ARG 10
+#define MFU_ERR           1000
+#define MFU_ERR_INVAL_ARG 1001
 
 /* DCP-specific error codes */
-#define ERR_DCP      100
-#define ERR_DCP_COPY 101
+#define MFU_ERR_DCP      1100
+#define MFU_ERR_DCP_COPY 1101
 
 /* DAOS-specific error codes*/
-#define ERR_DAOS            200
-#define ERR_DAOS_INVAL_PRFX 201
+#define MFU_ERR_DAOS            4000
+#define MFU_ERR_DAOS_INVAL_ARG  4001
+
+/* Error macros */
+#define MFU_ERRF "%s(%d)"
+#define MFU_ERRP(rc) "MFU_ERR", rc
 
 #endif /* MFU_ERRORS_H */
 

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -56,7 +56,7 @@ struct stat64;
 /* calls access, and retries a few times if we get EIO or EINTR */
 int mfu_file_access(const char* path, int amode, mfu_file_t* mfu_file);
 int mfu_access(const char* path, int amode);
-int daos_access(const char* path, int amode);
+int daos_access(const char* path, int amode, mfu_file_t* mfu_file);
 
 /* calls lchown, and retries a few times if we get EIO or EINTR */
 int mfu_lchown(const char* path, uid_t owner, gid_t group);

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -406,12 +406,6 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
     *flag_valid = 0;
     *flag_copy_into_dir = 0;
 
-    if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
-        if (num != 1) {
-            MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
-        }
-    }
-
     /* need at least two paths to have a shot at being valid */
     if (num < 1 || paths == NULL || destpath == NULL) {
         return;
@@ -426,6 +420,15 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
 
     /* just have rank 0 check */
     if(rank == 0) {
+        /* DAOS-specific error checks*/
+        if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
+            if (num != 1) {
+                MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
+            }
+            valid = 0;
+            goto bcast;
+        }
+        
         /* count number of readable source paths */
         uint64_t i;
         int num_readable = 0;

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -424,9 +424,9 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
         if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
             if (num != 1) {
                 MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
+                valid = 0;
+                goto bcast;
             }
-            valid = 0;
-            goto bcast;
         }
         
         /* count number of readable source paths */

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -107,80 +107,89 @@ void daos_bcast_handle(
     mfu_free(&global.iov_buf);
 }
 
-void daos_connect(
+int daos_connect(
   int rank,
   const char* svc,
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,
   daos_handle_t* coh,
+  bool connect_pool,
   bool create_cont)
 {
     /* TODO: if src daos path and dst daos path are false 
      * skip connecting to daos pool */
 
+    /* assume failure until otherwise */
+    int valid = 0;
+    int rc;
+
     /* have rank 0 connect to the pool and container,
      * we'll then broadcast the handle ids from rank 0 to everyone else */
     if (rank == 0) {
-        d_rank_list_t* svcl = daos_rank_list_parse(svc, ":");
-        if (svcl == NULL) {
-            MFU_ABORT(-1, "Failed to parse DAOS rank list: '%s'", svc);
+        /* Parse svc and connect to DAOS pool */
+        if (connect_pool) {
+            d_rank_list_t* svcl = daos_rank_list_parse(svc, ":");
+            if (svcl == NULL) {
+                MFU_LOG(MFU_LOG_ERR, "Failed to parse DAOS rank list: '%s'", svc);
+                goto bcast;
+            }
+
+            daos_pool_info_t pool_info;
+            rc = daos_pool_connect(pool_uuid, NULL, svcl, DAOS_PC_RW,
+                    poh, &pool_info, NULL);
+            if (rc != 0) {
+                MFU_LOG(MFU_LOG_ERR, "Failed to connect to pool");
+                goto bcast;
+            }
+            d_rank_list_free(svcl);
         }
 
-        /* Connect to DAOS pool */
-        daos_pool_info_t pool_info;
-        int rc = daos_pool_connect(pool_uuid, NULL, svcl, DAOS_PC_RW,
-                               poh, &pool_info, NULL);
+        /* Try to open the container */
+        daos_cont_info_t co_info;
+        rc = daos_cont_open(*poh, cont_uuid, DAOS_COO_RW, coh, &co_info, NULL);
+        
+        /* If NOEXIST we create it */
         if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to connect to pool");
+            if (!create_cont) {
+                MFU_LOG(MFU_LOG_ERR, "Failed to open DFS container");
+                goto bcast;
+            }
+            
+            rc = dfs_cont_create(*poh, cont_uuid, NULL, NULL, NULL);
+            if (rc != 0) {
+                MFU_LOG(MFU_LOG_ERR, "Failed to create DFS container");
+                goto bcast;
+            }
+
+            /* try to open it again */
+            rc = daos_cont_open(*poh, cont_uuid, DAOS_COO_RW, coh, &co_info, NULL);
+            if (rc != 0) {
+                MFU_LOG(MFU_LOG_ERR, "Failed to open DFS container");
+                goto bcast;
+            }
         }
-        d_rank_list_free(svcl);
+
+        /* everything looks good so far */
+        valid = 1;
+    }
+
+bcast:
+    /* broadcast valid from rank 0 */
+    MPI_Bcast(&valid, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    /* return if invalid */
+    if (valid == 0) {
+        return -1;
     }
 
     /* broadcast pool handle from rank 0 */
     daos_bcast_handle(rank, poh, poh, POOL_HANDLE);
 
-    /* open the container and broadcast handle from rank 0 */
-    daos_cont_create_open(rank, cont_uuid, poh, coh, create_cont);
-}
-
-void daos_cont_create_open(
-    int rank,
-    uuid_t cont_uuid,
-    daos_handle_t* poh,
-    daos_handle_t* coh,
-    bool create_cont)
-{
-    int rc;
-
-    /* rank 0 will open it and broadcast the handle */
-    if (rank == 0) {
-        /* try to open it */
-        daos_cont_info_t co_info;
-        rc = daos_cont_open(*poh, cont_uuid, DAOS_COO_RW, coh, &co_info, NULL);
-
-        /* If NOEXIST we create it */
-        if (rc != 0) {
-            if (!create_cont) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to open DFS container");
-            }
-            else {
-                rc = dfs_cont_create(*poh, cont_uuid, NULL, NULL, NULL);
-                if (rc != 0) {
-                    MFU_LOG(MFU_LOG_ERR, "Failed to create DFS container");
-                }
-
-                /* try to open it again */
-                rc = daos_cont_open(*poh, cont_uuid, DAOS_COO_RW, coh, &co_info, NULL);
-                if (rc != 0) {
-                    MFU_LOG(MFU_LOG_ERR, "Failed to open DFS container");
-                }
-            }
-        }
-    }
-
     /* broadcast container handle from rank 0 */
     daos_bcast_handle(rank, coh, poh, CONT_HANDLE);
+
+    return 0;
 }
 #endif
 

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -134,6 +134,15 @@ void daos_connect(
   daos_handle_t* poh,
   daos_handle_t* coh
 );
+
+/* Create the container if it doesn't exist.
+ * Then open it */
+void daos_cont_create_open(
+  int rank,
+  uuid_t cont_uuid,
+  daos_handle_t* poh,
+  daos_handle_t* coh
+);
 #endif
 
 /* initialize mfu library,

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -132,16 +132,18 @@ void daos_connect(
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,
-  daos_handle_t* coh
+  daos_handle_t* coh,
+  bool create_cont
 );
 
-/* Create the container if it doesn't exist.
+/* Conditionally create the container if it doesn't exist.
  * Then open it */
 void daos_cont_create_open(
   int rank,
   uuid_t cont_uuid,
   daos_handle_t* poh,
-  daos_handle_t* coh
+  daos_handle_t* coh,
+  bool create_cont
 );
 #endif
 

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -126,23 +126,14 @@ void daos_bcast_handle(
 );
 
 /* connect to DAOS pool, and then open container */
-void daos_connect(
+int daos_connect(
   int rank,
   const char* svc,
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,
   daos_handle_t* coh,
-  bool create_cont
-);
-
-/* Conditionally create the container if it doesn't exist.
- * Then open it */
-void daos_cont_create_open(
-  int rank,
-  uuid_t cont_uuid,
-  daos_handle_t* poh,
-  daos_handle_t* coh,
+  bool connect_pool,
   bool create_cont
 );
 #endif

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -577,7 +577,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         mfu_finalize();
         MPI_Finalize();
-        return ERR_INVAL_ARG;
+        return rc;
     }
 
     rc = daos_init();
@@ -593,8 +593,8 @@ int main(int argc, char** argv)
      * prefix since the path is mapped to the root
      * of the container in the DAOS DFS mount */
     if (!daos_uuid_valid(src_pool_uuid) || !daos_uuid_valid(dst_pool_uuid)) {
-        rc =daos_set_paths(rank, argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
-            dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
+        rc = daos_set_paths(rank, argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
+                dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
         if (rc != 0) {
             mfu_finalize();
             MPI_Finalize();
@@ -608,7 +608,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         mfu_finalize();
         MPI_Finalize();
-        return ERR_INVAL_ARG;
+        return rc;
     }
     
     /* check if DAOS source and destination containers are in the same pool */

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -388,7 +388,6 @@ int main(int argc, char** argv)
         {"daos-dst-cont"        , required_argument, 0, 'Y'},
         {"daos-src-svcl"        , required_argument, 0, 'z'},
         {"daos-dst-svcl"        , required_argument, 0, 'Z'},
-        {"daos-svcl"        , required_argument, 0, 'a'},
         {"daos-prefix"          , required_argument, 0, 'X'},
         {"input"                , required_argument, 0, 'i'},
         {"chunksize"            , required_argument, 0, 'k'},
@@ -522,10 +521,6 @@ int main(int argc, char** argv)
                 src_svc = MFU_STRDUP(optarg);
                 break;
             case 'Z':
-                dst_svc = MFU_STRDUP(optarg);
-                break;
-            case 'a':
-                src_svc = MFU_STRDUP(optarg);
                 dst_svc = MFU_STRDUP(optarg);
                 break;
             case 'X':

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -604,7 +604,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         if (rank == 0) {
             MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS_INVAL_ARG));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
         }
         mfu_finalize();
         MPI_Finalize();
@@ -628,7 +628,7 @@ int main(int argc, char** argv)
                 dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
         if (rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS_INVAL_ARG));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
             local_daos_error = true;
         }
     }
@@ -639,7 +639,7 @@ int main(int argc, char** argv)
                 dst_pool_uuid, dst_cont_uuid, src_svc, dst_svc, dfs_prefix);
         if (rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS_INVAL_ARG));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
             local_daos_error = true;
         }
     }
@@ -674,7 +674,7 @@ int main(int argc, char** argv)
         rc = dfs_mount(src_poh, src_coh, O_RDWR, &dfs1);
         if (rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS): "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
             local_daos_error = true;
         }
     }
@@ -688,7 +688,7 @@ int main(int argc, char** argv)
         }
         if (rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS): "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
             local_daos_error = true;
         }
     }
@@ -698,7 +698,7 @@ int main(int argc, char** argv)
     if (global_daos_error) {
         if (rank == 0) {
            MFU_LOG(MFU_LOG_ERR, "Detected one or more DAOS errors: "
-                   MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS));
+                   MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
         }
         tmp_rc = daos_fini();
         mfu_finalize();
@@ -738,7 +738,7 @@ int main(int argc, char** argv)
     if (numpaths_src == 0) {
         if(rank == 0) {
             MFU_LOG(MFU_LOG_ERR, "A source and destination path is needed: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_INVAL_ARG));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_INVAL_ARG));
         }
 
         mfu_param_path_free_all(numpaths, paths);
@@ -760,7 +760,7 @@ int main(int argc, char** argv)
     if (!valid) {
         if(rank == 0) {
             MFU_LOG(MFU_LOG_ERR, "Invalid src/dest paths provided. Exiting run: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_INVAL_ARG));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_INVAL_ARG));
         }
         mfu_param_path_free_all(numpaths, paths);
         mfu_free(&paths);
@@ -868,7 +868,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         if (rank == 0) {
             MFU_LOG(MFU_LOG_ERR, "One or more errors were detected while copying: "
-                    MFU_ERRF, MFU_ERRP(MFU_ERR_DCP_COPY));
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DCP_COPY));
         }
     }
 

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -138,9 +138,6 @@ static int daos_set_paths(
     bool prefix_on_src = false;
     bool prefix_on_dst = false;
 
-    /* TODO: handle when not UNS, but check_prefix succeeds. */
-    /* TODO: handle when UNS but no src or dst svc supplied */
-
     /* find out if a dfs_prefix is being used,
      * if so, then that means that the container
      * is not being copied from the root of the
@@ -149,7 +146,8 @@ static int daos_set_paths(
         struct duns_attr_t dattr = {0};
         rc = duns_resolve_path(dfs_prefix, &dattr);
         if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS UNS path");
+            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS PREFIX UNS path");
+            return 1;
         }
 
         /* figure out if prefix is on dst or src for
@@ -169,7 +167,7 @@ static int daos_set_paths(
         }
 
         if (!prefix_on_src && !prefix_on_dst) {
-            MFU_LOG(MFU_LOG_ERR, "Invalid DAOS prefix");
+            MFU_LOG(MFU_LOG_ERR, "DAOS prefix does not match source or destination");
             return 1;
         }
     }
@@ -183,8 +181,8 @@ static int daos_set_paths(
      *
      * For each of the source and destination,
      * if it is not using a prefix then assume
-     * is is a daos path for UNS. If resolve path
-     * doesn't succeed then set accordingly */
+     * it is a daos path for UNS. If resolve path
+     * doesn't succeed then it might be a POSIX path */
     if (!prefix_on_src) {
         struct duns_attr_t src_dattr = {0};
         int src_rc = duns_resolve_path(src_path, &src_dattr);

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -178,7 +178,7 @@ static int daos_set_paths(
         struct duns_attr_t dattr = {0};
         rc = duns_resolve_path(dfs_prefix, &dattr);
         if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS PREFIX UNS path");
+            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS Prefix UNS path");
             return 1;
         }
 

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -622,7 +622,7 @@ int main(int argc, char** argv)
     /* connect to DAOS source pool if uuid is valid */
     if (mfu_src_file->type == DAOS) {
         /* if DAOS source pool uuid is valid, then set source file type to DAOS */
-        daos_connect(rank, src_svc, src_pool_uuid, src_cont_uuid, &src_poh, &src_coh); 
+        daos_connect(rank, src_svc, src_pool_uuid, src_cont_uuid, &src_poh, &src_coh, false);
     }
 
     int daos_rc = 0;
@@ -630,7 +630,7 @@ int main(int argc, char** argv)
         if (!same_pool) {
             /* if DAOS is the source and destination type, and containers are in different pools,
              * then connect to the second pool */
-            daos_connect(rank, dst_svc, dst_pool_uuid, dst_cont_uuid, &dst_poh, &dst_coh); 
+            daos_connect(rank, dst_svc, dst_pool_uuid, dst_cont_uuid, &dst_poh, &dst_coh, true); 
         } else {
             /* Containers are using the same pool uuid.
              * Make sure they are also using the same svc.
@@ -648,7 +648,7 @@ int main(int argc, char** argv)
             }
             
             /* open the container, creating if it doesn't exist */
-            daos_cont_create_open(rank, dst_cont_uuid, &src_poh, &dst_coh);
+            daos_cont_create_open(rank, dst_cont_uuid, &src_poh, &dst_coh, true);
         }
     }
 

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -646,31 +646,9 @@ int main(int argc, char** argv)
                     return ERR_INVAL_ARG;
                 }
             }
-            if (rank == 0) {
-                /* create container in same pool */
-                daos_cont_info_t co_info;
-                rc = daos_cont_open(src_poh, dst_cont_uuid, DAOS_COO_RW, &dst_coh, &co_info, NULL);
-
-                /* If NOEXIST we create it */
-                if (rc != 0) {
-                    /* create the container */
-                    uuid_t cuuid;
-                    rc = dfs_cont_create(src_poh, cuuid, NULL, NULL, NULL);
-                    if (rc != 0) {
-                        MFU_LOG(MFU_LOG_ERR, "Failed to create DFS2 container");
-                    }
-
-                    /* try to open it again */
-                    rc = daos_cont_open(src_poh, cuuid, DAOS_COO_RW, &dst_coh, &co_info, NULL);
-                    if (rc != 0) {
-                        MFU_LOG(MFU_LOG_ERR, "Failed to open DFS2 container");
-                        daos_rc = 1;
-                    }
-                }
-            }
-
-            /* broadcast container handle from rank 0 */
-            daos_bcast_handle(rank, &dst_coh, &src_poh, CONT_HANDLE);
+            
+            /* open the container, creating if it doesn't exist */
+            daos_cont_create_open(rank, dst_cont_uuid, &src_poh, &dst_coh);
         }
     }
 


### PR DESCRIPTION
**common/mfu_errors.h**
- New file
- Defines some generic error codes, codes for dcp, and codes for DAOS
- Defines MFU_ERRF and MFU_ERRP for printing the error codes.
  - Formatted as: MFU_ERR(#)
  - Could be improved in the future to print the"string" error code instead of just MFU_ERR

**common/mfu_io**
- Defined daos_access

**common/mfu_param_path.c**
- mfu_param_path_check_copy - Return on DAOS error

**common/mfu_util**
- daos_connect
  - Added flag for whether or not to connect to pool
  - Added flag for whether or not to auto-create the destination container
    - No longer creates the source container automatically
  - These flags allow a centralized way to capture errors. I.e. only one bcast is needed for pool connection, cont connection, cont creation
  - Rank 0 now tracks and broadcasts any errors before trying to share the handles
  - Function returns an error

**dcp/dcp.c**
- Use the new error codes from mfu_error.h
- DAOS errors are generally handled more precisely
  - Each process tracks local errors, and stops making DAOS calls once it has run into an error
  - Allreduce on local DAOS errors, so all processes will know to exit
  - Check DAOS arguments before trying to make DAOS calls
  - Refactored daos_connect calls to better capture errors and exit if found
  - More gracefully handle a failed daos_init call
  - Exit if DAOS source is DAOS destination