### PR TITLE
daos: mfu_file_unlink and daos_unlink implementation

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2091,7 +2091,7 @@ static int mfu_copy_files(mfu_flist list, uint64_t chunk_size,
                     rc = -1;
 #if 0
                     /* delete destination file */
-                    int unlink_rc = mfu_unlink(dest);
+                    int unlink_rc = mfu_file_unlink(dest, mfu_dst_file);
                     if (unlink_rc != 0) {
                         MFU_LOG(MFU_LOG_ERR, "Failed to unlink `%s' (errno=%d %s)",
                                   name, errno, strerror(errno)

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -354,7 +354,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                         /* unlink files here if remove option is on,
                          * and dtype is known without a stat */
                         if (REMOVE_FILES && (entry->d_type != DT_DIR)) {
-                            mfu_unlink(newpath);
+                            mfu_file_unlink(newpath, mfu_file);
                         } else {
                             /* we can read object type from directory entry */
                             have_mode = 1;
@@ -372,7 +372,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                             /* unlink files here if remove option is on,
                              * and stat was necessary to get type */
                             if (REMOVE_FILES && !S_ISDIR(st.st_mode)) {
-                                mfu_unlink(newpath);
+                                mfu_file_unlink(newpath, mfu_file);
                             } else {
                                 mfu_flist_insert_stat(CURRENT_LIST, newpath, mode, &st);
                             }
@@ -527,7 +527,7 @@ static void walk_stat_process(CIRCLE_handle* handle)
     /* TODO: filter items by stat info */
 
     if (REMOVE_FILES && !S_ISDIR(st.st_mode)) {
-        mfu_unlink(path);
+        mfu_file_unlink(path, mfu_file);
     } else {
         /* record info for item in list */
         mfu_flist_insert_stat(CURRENT_LIST, path, st.st_mode, &st);

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -1078,6 +1078,67 @@ int mfu_file_ftruncate(mfu_file_t* mfu_file, off_t length)
     }
 }
 
+/* unlink a file */
+int mfu_file_unlink(const char* file, mfu_file_t* mfu_file)
+{
+    if (mfu_file->type == POSIX) {
+        int rc = mfu_unlink(file);
+        return rc;
+    } else if (mfu_file->type == DAOS) {
+        int rc = daos_unlink(file, mfu_file);
+        return rc;
+    } else {
+        MFU_ABORT(-1, "File type not known, type=%d",
+                  mfu_file->type);
+    } 
+}
+
+/* emulates unlink on a DAOS file or symlink */
+int daos_unlink(const char* file, mfu_file_t* mfu_file)
+{
+#ifdef DAOS_SUPPORT
+    char* name     = NULL;
+    char* dir_name = NULL;
+    parse_filename(file, &name, &dir_name);
+    assert(dir_name);
+
+    /* Need to lookup parent directory in DFS */
+    dfs_obj_t* parent = NULL;
+    mode_t mode;
+    int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, &mode, NULL);
+    if (parent == NULL) {
+        MFU_LOG(MFU_LOG_ERR, "dfs_lookup %s failed", dir_name);
+        errno = ENOENT;
+        rc = -1;
+    } 
+    else {
+        /* only allow regular files and symlinks */
+        if (!S_ISREG(mode) && !S_ISLNK(mode)) {
+            MFU_LOG(MFU_LOG_ERR, "Invalid entry type (not a file or symlink)");
+            errno = EINVAL;
+            rc = -1;
+        }
+        else {
+            /* remove the file */
+            rc = dfs_remove(mfu_file->dfs, parent, name, false, NULL);
+            if (rc) {
+                MFU_LOG(MFU_LOG_ERR, "dfs_remove failed (%d %s)",
+                        rc, strerror(rc));
+                errno = rc;
+                rc = -1;
+            }
+        }
+        /* close the parent, ignoring errors since they have no direct impact */
+        dfs_release(parent);
+    }
+
+    mfu_free(&name);
+    mfu_free(&dir_name);
+
+    return rc; 
+#endif
+}
+
 /* delete a file */
 int mfu_unlink(const char* file)
 {
@@ -1293,7 +1354,7 @@ int daos_closedir(DIR* _dirp, mfu_file_t* mfu_file)
     struct dfs_mfu_t *dirp = (struct dfs_mfu_t *)_dirp;
     int rc = dfs_release(dirp->dir);
     if (rc) {
-        MFU_LOG(MFU_LOG_ERR, "dfs_release failed (%d)",
+        MFU_LOG(MFU_LOG_ERR, "dfs_release failed (%d %s)",
                 rc, strerror(rc));
         errno = rc;
         rc = -1;

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -83,7 +83,6 @@ int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
 
 /* call mknod, retry a few times on EINTR or EIO */
 int mfu_file_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
-/* just a noop, since there is no daos_mknod */
 int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
 int mfu_mknod(const char* path, mode_t mode, dev_t dev);
 
@@ -147,6 +146,8 @@ int daos_ftruncate(mfu_file_t* mfu_file, off_t length);
 int mfu_ftruncate(int fd, off_t length);
 
 /* delete a file */
+int mfu_file_unlink(const char* file, mfu_file_t* mfu_file);
+int daos_unlink(const char* file, mfu_file_t* mfu_file);
 int mfu_unlink(const char* file);
 
 /* force flush of written data */


### PR DESCRIPTION
Added implementation for mfu_file_unlink and daos_unlink.
Updated mfu_flist_copy.c and mfu_flist_walk.c to use the
new mfu_file_unlink.

The following files still have references to mfu_unlink,
but I don't believe that can/should be updated:
mfu_flist_remove.c
dbcast.c
dreln.c
copy.c
dbz2.c

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>